### PR TITLE
Update  vulnerable libraries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Yevhen Cherkes
+Copyright (c) 2021-2014 Yevhen Cherkes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 Avro deserializer for Multiple Event Types in the Same Topic.
 ===========================================================================================
 
-[![nuget version](https://img.shields.io/badge/Nuget-v1.0.4-blue)](https://www.nuget.org/packages/YCherkes.SchemaRegistry.Serdes.Avro)
+[![nuget version](https://img.shields.io/badge/Nuget-v1.0.5-blue)](https://www.nuget.org/packages/YCherkes.SchemaRegistry.Serdes.Avro)
 [![nuget downloads](https://img.shields.io/nuget/dt/YCherkes.SchemaRegistry.Serdes.Avro?label=Downloads)](https://www.nuget.org/packages/YCherkes.SchemaRegistry.Serdes.Avro)
 
 To install YCherkes.SchemaRegistry.Serdes.Avro from within Visual Studio, search for YCherkes.SchemaRegistry.Serdes.Avro in the NuGet Package Manager UI, or run the following command in the Package Manager Console:
 
 ```
-Install-Package YCherkes.SchemaRegistry.Serdes.Avro -Version 1.0.4
+Install-Package YCherkes.SchemaRegistry.Serdes.Avro -Version 1.0.5
 ```
 
 To add a reference to a dotnet core project, execute the following at the command line:
 
 ```
-dotnet add package -v 1.0.4 YCherkes.SchemaRegistry.Serdes.Avro
+dotnet add package -v 1.0.5 YCherkes.SchemaRegistry.Serdes.Avro
 ```
 
 

--- a/src/Samples/Samples.Akka.Streams.Kafka/Samples.Akka.Streams.Kafka.csproj
+++ b/src/Samples/Samples.Akka.Streams.Kafka/Samples.Akka.Streams.Kafka.csproj
@@ -7,8 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams.Kafka" Version="1.5.15" />
-    <PackageReference Include="Apache.Avro" Version="1.11.3" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Samples.Confluent.Kafka/Samples.Confluent.Kafka.csproj
+++ b/src/Samples/Samples.Confluent.Kafka/Samples.Confluent.Kafka.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Avro" Version="1.11.3" />
-    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\YCherkes.SchemaRegistry.Serdes.Avro\YCherkes.SchemaRegistry.Serdes.Avro.csproj" />
   </ItemGroup>
 

--- a/src/YCherkes.SchemaRegistry.Serdes.Avro/YCherkes.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/YCherkes.SchemaRegistry.Serdes.Avro/YCherkes.SchemaRegistry.Serdes.Avro.csproj
@@ -12,7 +12,8 @@
     <RepositoryUrl>https://github.com/ycherkes/multi-schema-avro-desrializer</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Version>1.0.5</Version>
-    <PackageReleaseNotes>Added SpecificTypes helper.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated vulnerable Apache.Avro 1.10.2 library and all dependants.</PackageReleaseNotes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +26,10 @@
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/YCherkes.SchemaRegistry.Serdes.Avro/YCherkes.SchemaRegistry.Serdes.Avro.csproj
+++ b/src/YCherkes.SchemaRegistry.Serdes.Avro/YCherkes.SchemaRegistry.Serdes.Avro.csproj
@@ -4,21 +4,21 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Avro deserializer for reading messages serialized with multiple schemas.</Description>
-    <Copyright>Copyright 2021 Yevhen Cherkes.</Copyright>
+    <Copyright>Copyright 2021-$([System.DateTime]::Now.Year) Yevhen Cherkes.</Copyright>
     <Authors>Yevhen Cherkes</Authors>
     <PackageTags>Kafka;Confluent;librdkafka;multiple event types</PackageTags>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ycherkes/multi-schema-avro-desrializer</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ycherkes/multi-schema-avro-desrializer</RepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <PackageReleaseNotes>Added SpecificTypes helper.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.8.1" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="1.8.1" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="1.8.1" />
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="2.3.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/YCherkes.SchemaRegistry.Serdes.UnitTests/YCherkes.SchemaRegistry.Serdes.UnitTests.csproj
+++ b/src/YCherkes.SchemaRegistry.Serdes.UnitTests/YCherkes.SchemaRegistry.Serdes.UnitTests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
Update all libraries because Apache.Avro < 1.11.0 has vulnerabilities (see https://www.nuget.org/packages/Apache.Avro/1.10.2 and https://github.com/advisories/GHSA-868x-rg4c-cjqg)